### PR TITLE
🐛 Only create events in Unicorn when bizStep is commissioning

### DIFF
--- a/helpers/epcis-events.js
+++ b/helpers/epcis-events.js
@@ -19,11 +19,7 @@ const wrapObjectEvent = function (objectEvent) {
       '@xmlns:smile': 'http://ns.smile-project.de/epcis',
       '@schemaVersion': '1.2',
       '@creationDate': '2018-05-15T14:07:44.834Z',
-      'EPCISBody': {
-        'EventList': {
-          'ObjectEvent': objectEvent
-        }
-      }
+      'EPCISBody': { 'EventList': { 'ObjectEvent': objectEvent } }
     }
   }
 };
@@ -35,92 +31,37 @@ const getEventXml = function (objectEvent) {
 
 const receiving = function (sscc, depotId) {
   return getEventXml({
-    'eventTime': {
-      '#text': getCurrentTimeAsIsoString()
-    },
-    'eventTimeZoneOffset': {
-      '#text': '+02:00'
-    },
-    'epcList': {
-      'epc': {
-        '#text': sscc
-      }
-    },
-    'action': {
-      '#text': 'OBSERVE'
-    },
-    'bizStep': {
-      '#text': 'urn:epcglobal:cbv:bizstep:receiving'
-    },
-    'bizLocation': {
-      'id': {
-        '#text': depotId
-      }
-    }
+    'eventTime': { '#text': getCurrentTimeAsIsoString() },
+    'eventTimeZoneOffset': { '#text': '+02:00' },
+    'epcList': { 'epc': { '#text': sscc } },
+    'action': { '#text': 'OBSERVE' },
+    'bizStep': { '#text': 'urn:epcglobal:cbv:bizstep:receiving' },
+    'bizLocation': { 'id': { '#text': depotId } }
   });
 };
 
 const shipping = function (sscc, depotId, receiverId) {
   return getEventXml({
-    'eventTime': {
-      '#text': getCurrentTimeAsIsoString()
-    },
-    'eventTimeZoneOffset': {
-      '#text': '+02:00'
-    },
-    'epcList': {
-      'epc': {
-        '#text': sscc
-      }
-    },
-    'action': {
-      '#text': 'OBSERVE'
-    },
-    'bizStep': {
-      '#text': 'urn:epcglobal:cbv:bizstep:shipping'
-    },
-    'disposition': {
-      '#text': 'urn:epcglobal:cbv:disp:in_transit'
-    },
-    'bizLocation': {
-      'id': {
-        '#text': depotId
-      }
-    },
-    'smile:personId': [
-      { '#text': 'fahrerID' },
-      { '#text': receiverId }
-    ]
+    'eventTime': { '#text': getCurrentTimeAsIsoString() },
+    'eventTimeZoneOffset': { '#text': '+02:00' },
+    'epcList': { 'epc': { '#text': sscc } },
+    'action': { '#text': 'OBSERVE' },
+    'bizStep': { '#text': 'urn:epcglobal:cbv:bizstep:shipping' },
+    'disposition': { '#text': 'urn:epcglobal:cbv:disp:in_transit' },
+    'bizLocation': { 'id': { '#text': depotId } },
+    'smile:personId': [ { '#text': 'fahrerID' }, { '#text': receiverId } ]
   });
 };
 
 const receiving2 = function (sscc, receiverId) {
   return getEventXml({
-    'eventTime': {
-      '#text': getCurrentTimeAsIsoString()
-    },
-    'eventTimeZoneOffset': {
-      '#text': '+02:00'
-    },
-    'epcList': {
-      'epc': {
-        '#text': sscc
-      }
-    },
-    'action': {
-      '#text': 'OBSERVE'
-    },
-    'bizStep': {
-      '#text': 'urn:epcglobal:cbv:bizstep:receiving'
-    },
-    'bizLocation': {
-      'id': {
-        '#text': 'fahrerId'
-      }
-    },
-    'smile:personId': {
-      '#text': receiverId
-    }
+    'eventTime': { '#text': getCurrentTimeAsIsoString() },
+    'eventTimeZoneOffset': { '#text': '+02:00' },
+    'epcList': { 'epc': { '#text': sscc } },
+    'action': { '#text': 'OBSERVE' },
+    'bizStep': { '#text': 'urn:epcglobal:cbv:bizstep:receiving' },
+    'bizLocation': { 'id': { '#text': 'fahrerId' } },
+    'smile:personId': { '#text': receiverId }
   });
 };
 

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,19 +1,7 @@
 var request = require('request-promise');
+var unicornEvents = require('./unicorn-events');
+var epcisEvents = require('./epcis-events');
 const UNICORN_BASE_URL = process.env.UNICORN_BASE_URL || "http://unicorn:8080/unicorn";
-
-const getEPCISQueryDocumentForObjectEvent = (objectEvent) => `
-    <epcisq:EPCISQueryDocument schemaVersion="1.2" creationDate="2019-03-25T14:29:56.7Z" xmlns:epcis="urn:epcglobal:epcis:xsd:1" xmlns:epcismd="urn:epcglobal:epcis-masterdata:xsd:1" xmlns:sbdh="http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader" xmlns:epcisq="urn:epcglobal:epcis-query:xsd:1" xmlns:epcglobal="urn:epcglobal:xsd:1" xmlns:eecc="http://ns.eecc.info/epcis" xmlns:smile="http://ns.smile-project.de/epcis" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="ParcelDataCreated.xsd">
-      <EPCISBody>
-        <epcisq:QueryResults>
-          <queryName>SimpleEventQuery</queryName>
-          <resultsBody>
-            <EventList>
-              ${objectEvent}
-            </EventList>
-          </resultsBody>
-        </epcisq:QueryResults>
-      </EPCISBody>
-    </epcisq:EPCISQueryDocument>`;
 
 const sendEventToUnicorn = (event) => {
   return request({
@@ -29,7 +17,8 @@ const sendSuccessfullUnicornResponse = (req, res, next) => {
 };
 
 module.exports = {
-  getEPCISQueryDocumentForObjectEvent,
   sendEventToUnicorn,
-  sendSuccessfullUnicornResponse
+  sendSuccessfullUnicornResponse,
+  unicornEvents,
+  epcisEvents
 };

--- a/helpers/unicorn-events.js
+++ b/helpers/unicorn-events.js
@@ -1,0 +1,97 @@
+const ETParcelDataCreated = (sisEvent) => {
+  const {
+    eventTime,
+    eventTimeZoneOffset,
+    epcList: { epc },
+    action,
+    bizStep,
+    disposition,
+    readPoint: { id: readPointId } = { },
+    bizLocation: { id: bizLocationId } = { },
+    extension: {
+      ilmd: {
+        'smile:sender': {
+          'smile:city': senderCity,
+          'smile:country': senderCountry,
+          'smile:firstName': senderFirstname,
+          'smile:lastName': senderLastname,
+          'smile:gln': senderGLN,
+          'smile:streetName': senderStreetName,
+          'smile:streetNumber': senderStreetNumber,
+          'smile:zip': senderZip,
+          'smile:organisation': senderOrganisation
+        } = { },
+        'smile:depot': {
+          'smile:city': depotCity,
+          'smile:country': depotCountry,
+          'smile:organisation': depotOrganisation,
+          'smile:streetName': depotStreetName,
+          'smile:streetNumber': depotStreetNumber,
+          'smile:zip': depotZip
+        } = { },
+        'smile:receiver': {
+          'smile:firstName': receiverFirstname,
+          'smile:lastName': receiverLastname,
+          'smile:smileUserId': receiverSmileUserId
+        } = { },
+        'smile:item': {
+          'smile:grossWeight': {
+            'smile:uom': grossWeightUOM,
+            'smile:value': grossWeightValue
+          } = { },
+          'smile:height': {
+            'smile:uom': heightUOM,
+            'smile:value': heightValue
+          } = { },
+          'smile:width': {
+            'smile:uom': widthUOM,
+            'smile:value': widthValue
+          } = { },
+          'smile:length': {
+            'smile:uom': lengthUOM,
+            'smile:value': lengthValue
+          }
+        } = { },
+        'smile:dateOfPlannedDelivery': {
+          _: dateOfPlannedDelivery
+        } = { },
+        'smile:carrierItemId': {
+          _: carrierItemId
+        } = { }
+      }
+    }
+  } = sisEvent.ObjectEvent;
+  return {
+    "initialSendDate": eventTime,
+    "length": lengthValue,
+    "dateOfPlannedDelivery": dateOfPlannedDelivery,
+    "depotZIP": depotZip,
+    "receiverLastName": receiverLastname,
+    "receiverID": receiverSmileUserId,
+    "depotID": "partyhuetchen",
+    "height": heightValue,
+    "senderStreetNumber": senderStreetNumber,
+    "senderFirstName": senderFirstname,
+    "senderZIP": senderZip,
+    "depotCity": depotCity,
+    "depotStreetNumber": depotStreetNumber,
+    "width": widthValue,
+    "receiverFirstName": receiverFirstname,
+    "depotStreetName": depotStreetName,
+    "sscc": epc,
+    "senderOrganization": senderOrganisation,
+    "depotCountry": depotCountry,
+    "senderOrganizationGLN": senderGLN,
+    "senderCity": senderCity,
+    "bizStep": bizStep,
+    "senderStreetName": senderStreetName,
+    "depotName": depotOrganisation,
+    "grossWeight": grossWeightValue,
+    "senderLastName": senderLastname,
+    "senderCountry": senderCountry
+  };
+};
+
+module.exports = {
+  ETParcelDataCreated
+};

--- a/helpers/unicorn-events.js
+++ b/helpers/unicorn-events.js
@@ -68,7 +68,7 @@ const ETParcelDataCreated = (sisEvent) => {
     "depotZIP": depotZip,
     "receiverLastName": receiverLastname,
     "receiverID": receiverSmileUserId,
-    "depotID": "partyhuetchen",
+    "depotID": "",
     "height": heightValue,
     "senderStreetNumber": senderStreetNumber,
     "senderFirstName": senderFirstname,

--- a/package-lock.json
+++ b/package-lock.json
@@ -599,6 +599,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -752,6 +757,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
     },
     "xmlbuilder": {
       "version": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "unicorn-adapter": "^1.1.1",
+    "xml2js": "^0.4.19",
     "xmlbuilder": "^12.0.0"
   }
 }

--- a/routes/sis.js
+++ b/routes/sis.js
@@ -8,14 +8,20 @@ var unicornAdapter = require('../unicorn/unicorn').unicornAdapter;
 /* UNICORN subscriptions */
 
 router.post('/arrived-at-depot', function (req, res, next) {
-  const { sscc, depotID } = req.body;
+  let { sscc, depotID, depotOrganisation, depotFirstname, depotLastname } = req.body;
+  // If depot id is empty use available name
+  depotID = depotID === 'ERROR' ? undefined : depotID;
+  depotID = depotID || depotOrganisation || depotFirstname + depotLastname;
   const eventXml = epcisEvents.receiving(sscc, depotID);
   epcisEvents.send(eventXml);
   next();
 }, helpers.sendSuccessfullUnicornResponse);
 
 router.post('/pickup-reported', function (req, res, next) {
-  const { sscc, depotID, receiverID } = req.body;
+  let { sscc, depotID, receiverID, depotOrganisation, depotFirstname, depotLastname } = req.body;
+  // If depot id is empty use available name
+  depotID = depotID === 'ERROR' ? undefined : depotID;
+  depotID = depotID || depotOrganisation || depotFirstname + depotLastname;
   const eventXml = epcisEvents.shipping(sscc, depotID, receiverID);
   epcisEvents.send(eventXml);
   next();
@@ -58,10 +64,9 @@ router.post('/parcels', function (req, res, next) {
             return unicornAdapter.generateChimeraEvent(unicornEvent, 'ETParcelDataReceived', 'new');
           // Parcel arrives at depot or at the receiver
           case 'urn:epcglobal:cbv:bizstep:receiving':
-            break;
           // Parcel is picked up at depot
           case 'urn:epcglobal:cbv:bizstep:shipping':
-            break;
+          // Unknown bizStep
           default:
             break;
         }

--- a/routes/sis.js
+++ b/routes/sis.js
@@ -2,6 +2,8 @@ var express = require('express');
 var router = express.Router();
 var helpers = require('../helpers');
 var epcisEvents = require('../helpers/epcis-events');
+var parseXmlString = require('xml2js').parseString;
+var unicornAdapter = require('../unicorn/unicorn').unicornAdapter;
 
 /* UNICORN subscriptions */
 
@@ -37,16 +39,45 @@ router.post('/parcels', function (req, res, next) {
     // match ObjectEvents
     let match, objectEventRegExp = /(<ObjectEvent>[\s\S]*?<\/ObjectEvent>)/g;
     let $results = [];
-    // send every ObjectEvent match to Unicorn
     while ((match = objectEventRegExp.exec(payload)) !== null) {
-      const objectEvent = match[0];
-      const queryDocument = helpers.getEPCISQueryDocumentForObjectEvent(objectEvent);
-      $results.push(helpers.sendEventToUnicorn(queryDocument));
+      const objectEventXml = match[0];
+      // try parsing object events
+      const $objectEvent = new Promise(((resolve, reject) => {
+        parseXmlString(objectEventXml, {explicitArray : false}, (err, result) => {
+          if (err) reject(err);
+          else resolve(result);
+        });
+      }));
+      const $result = $objectEvent.then(result => {
+        const bizStepName = result.ObjectEvent.bizStep;
+        switch (bizStepName) {
+          // Creation of parcel data
+          case 'urn:epcglobal:cbv:bizstep:commissioning':
+            // convert SIS event to ETParcelDataCreated
+            const unicornEvent = helpers.unicornEvents.ETParcelDataCreated(result);
+            return unicornAdapter.generateChimeraEvent(unicornEvent, 'ETParcelDataReceived', 'new');
+          // Parcel arrives at depot or at the receiver
+          case 'urn:epcglobal:cbv:bizstep:receiving':
+            break;
+          // Parcel is picked up at depot
+          case 'urn:epcglobal:cbv:bizstep:shipping':
+            break;
+          default:
+            break;
+        }
+      });
+      $results.push($result);
     }
     // Send response
     Promise.all($results)
-      .then(results => res.json({ status: 'success' }))
-      .catch(error => res.status(500).json({ status: 'failed 😢', error: error }));
+      .then(results => {
+        console.info('Imported events: ' + results.join(", "));
+        res.json({ status: 'success', results });
+      })
+      .catch(error => {
+        console.error('Failed to import events:\n' + error);
+        res.status(500).json({ status: 'failed 😢', error });
+      });
   }
 });
 


### PR DESCRIPTION
Fixes a bug where new parcels where created in Chimera whenever SIS sent us information about a parcel. We only want to create parcels at the beginning. @carlaterboven suggested to use the `action` field which might be a better idea for the future. Or maybe a combination of both...